### PR TITLE
 Add keyboard shortcuts for show all and hide all annotations

### DIFF
--- a/client/src/mixins/shortcuts.js
+++ b/client/src/mixins/shortcuts.js
@@ -124,6 +124,16 @@ export default {
           }
         },
         {
+          default: ["q"],
+          name: "Show All",
+          function: this.showAll
+        },
+        {
+          default: ["w"],
+          name: "Hide All",
+          function: this.hideAll
+        },
+        {
           default: ["c"],
           name: "Center Image",
           function: this.fit


### PR DESCRIPTION
## Purpose

COCO-Annotator does not have keyboard shortcuts to show all and hide all annotations. Showing and hiding all annotations with keyboard shortcuts can save time when using pre-labels (hiding momentarily to make sure that the pre-labels are correctly on top of real defects) or when reviewing (ensuring whether the drawn defect is not on parts of the cell where there is no real defect).

* Press 'q' to show all annotations.
* Press 'w' to hide all annotations.

![Screenshot 2021-06-07 at 7 27 04 PM](https://user-images.githubusercontent.com/1751331/121056674-059aaa00-c7f1-11eb-81ea-221984e50b5b.png)

## Wishes

Please let me know if you think there is a more appropriate key binding for these two operations.