### PR TITLE
Enable tagging and filtering datasets

### DIFF
--- a/backend/database/datasets.py
+++ b/backend/database/datasets.py
@@ -14,6 +14,7 @@ class DatasetModel(DynamicDocument):
     name = StringField(required=True, unique=True)
     directory = StringField()
     thumbnails = StringField()
+    tags = DictField(default={})
     categories = ListField(default=[])
 
     owner = StringField(required=True)

--- a/backend/database/datasets.py
+++ b/backend/database/datasets.py
@@ -14,7 +14,6 @@ class DatasetModel(DynamicDocument):
     name = StringField(required=True, unique=True)
     directory = StringField()
     thumbnails = StringField()
-    tags = DictField(default={})
     categories = ListField(default=[])
 
     owner = StringField(required=True)

--- a/backend/database/datasets.py
+++ b/backend/database/datasets.py
@@ -22,6 +22,7 @@ class DatasetModel(DynamicDocument):
     annotate_url = StringField(default="")
 
     default_annotation_metadata = DictField(default={})
+    tags = DictField(default={})
 
     deleted = BooleanField(default=False)
     deleted_date = DateTimeField()

--- a/backend/webserver/api/datasets.py
+++ b/backend/webserver/api/datasets.py
@@ -235,7 +235,7 @@ class DatasetId(Resource):
     def post(self, dataset_id):
 
         """ Updates dataset by ID """
-        
+
         dataset = current_user.datasets.filter(id=dataset_id, deleted=False).first()
         if dataset is None:
             return {"message": "Invalid dataset id"}, 400
@@ -313,8 +313,7 @@ class DatasetData(Resource):
                 filters_dict[key] = []
             filters_dict[key].append(value)
         
-        # Get filtered list of datasets whose default_annotation_metadata 
-        # includes all keys in filters_dict and any of each key's possible values
+        # Get filtered list of datasets whose tags include all keys in filters_dict and any of each key's values
         datasets = []
         for dataset in current_user.datasets.filter(deleted=False):
             tags = dataset.tags

--- a/backend/webserver/api/datasets.py
+++ b/backend/webserver/api/datasets.py
@@ -344,6 +344,27 @@ class DatasetData(Resource):
             "categories": query_util.fix_ids(current_user.categories.filter(deleted=False).all())
         }
 
+
+@api.route('/tags')
+class AllUniqueTags(Resource):
+
+    @login_required
+    def get(self):
+        """ Endpoint called by dataset viewer client """
+        datasets = current_user.datasets.filter(deleted=False)
+        tags = []
+
+        for dataset in datasets:
+            for key, value in dataset.tags.items():
+                if len(value) > 0:
+                    tag_string = key + ":" + value  
+                    tags.append(tag_string)
+        
+        return { 
+            "tags": list(set(tags))
+        }        
+
+
 @api.route('/<int:dataset_id>/data')
 class DatasetDataId(Resource):
 

--- a/client/src/components/Metadata.vue
+++ b/client/src/components/Metadata.vue
@@ -2,12 +2,13 @@
   <div>
     <i
       class="fa fa-plus"
-      style="float: right; margin: 5px; color: green; cursor: pointer"
+      style="float: right; margin: 5px 5px 0 -5px; color: green; cursor: pointer;"
       @click="createMetadata"
     />
 
-    <p class="title" style="margin: 0">{{ title }}</p>
+    <p class="title mb-2">{{ title }}</p>
 
+    <!--
     <div class="row">
       <div class="col-sm">
         <p class="subtitle">{{ keyTitle }}</p>
@@ -16,18 +17,19 @@
         <p class="subtitle">{{ valueTitle }}</p>
       </div>
     </div>
+    -->
 
     <ul class="list-group" style="height: 50%;">
       <li v-if="metadataList.length == 0" class="list-group-item meta-item">
-        <i class="subtitle">No items in metadata.</i>
+        <i class="subtitle">{{ emptyMessage }}</i>
       </li>
       <li
         v-for="(object, index) in metadataList"
         :key="index"
         class="list-group-item meta-item"
       >
-        <div class="row" style="cell">
-          <div class="col-sm">
+        <div class="row d-flex justify-content-between" style="cell">
+          <div class="col-xs">
             <input
               v-model="object.key"
               type="text"
@@ -37,7 +39,7 @@
             />
           </div>
 
-          <div class="col-sm">
+          <div class="col-xs">
             <input
               v-model="object.value"
               type="text"
@@ -46,17 +48,19 @@
             />
           </div>
 
-          <div class="d-flex align-items-center">
+          <div class="col-xs d-flex align-items-center">
             <i
               class="fa fa-minus"
-               style="color:red; cursor: pointer"
+              style="color:red; cursor: pointer"
               @click="deleteMetadata(index)"
             />
           </div>
         </div>
+
+        
       </li>
 
-      <div :v-show="errorMessage" class="mt-3 text-danger small">
+      <div :v-show="errorMessage" class="text-danger small">
         {{ errorMessage }}
       </div>
     </ul>
@@ -77,15 +81,19 @@ export default {
     },
     keyTitle: {
       type: String,
-      default: "Keys"
+      default: "Key"
     },
     valueTitle: {
       type: String,
-      default: "Values"
+      default: "Value"
     },
     exclude: {
       type: String,
       default: ""
+    },
+    emptyMessage: {
+      type: String,
+      default: "No items in metadata"
     }
   },
   data() {
@@ -174,7 +182,8 @@ export default {
 
 .meta-item {
   background-color: inherit;
-  height: 30px;
+  padding-top: 2px !important;
+  padding-bottom: 2px !important;
   border: none;
 }
 

--- a/client/src/components/Metadata.vue
+++ b/client/src/components/Metadata.vue
@@ -2,7 +2,7 @@
   <div>
     <i
       class="fa fa-plus"
-      style="float: right; margin: 0 4px; color: green"
+      style="float: right; margin: 5px; color: green; cursor: pointer"
       @click="createMetadata"
     />
 
@@ -43,6 +43,14 @@
               type="text"
               class="meta-input"
               :placeholder="valueTitle"
+            />
+          </div>
+
+          <div class="d-flex align-items-center">
+            <i
+              class="fa fa-minus"
+               style="color:red; cursor: pointer"
+              @click="deleteMetadata(index)"
             />
           </div>
         </div>
@@ -107,6 +115,16 @@ export default {
     },
     createMetadata() {
       this.metadataList.push({ key: "", value: "" });
+    },
+    deleteMetadata(index) {
+      delete this.metadataList[index];
+      this.metadataList = this.metadataList.filter(metadata => metadata);
+      this.validateKeys();
+    },
+    clearEmptyItems() {
+      this.metadataList = this.metadataList.filter((metadata) => {
+        return metadata.key || metadata.value;
+      })
     },
     loadMetadata() {
       if (this.metadata != null) {

--- a/client/src/components/Metadata.vue
+++ b/client/src/components/Metadata.vue
@@ -33,6 +33,7 @@
               type="text"
               class="meta-input"
               :placeholder="keyTitle"
+              @input="validateKeys()"
             />
           </div>
 
@@ -46,6 +47,10 @@
           </div>
         </div>
       </li>
+
+      <div :v-show="errorMessage" class="mt-3 text-danger small">
+        {{ errorMessage }}
+      </div>
     </ul>
   </div>
 </template>
@@ -77,7 +82,8 @@ export default {
   },
   data() {
     return {
-      metadataList: []
+      metadataList: [],
+      errorMessage: null, 
     };
   },
   methods: {
@@ -116,7 +122,17 @@ export default {
           this.metadataList.push({ key: key, value: value });
         }
       }
-    }
+    },
+    validateKeys() {
+      const keys = this.metadataList.map(metadata => metadata.key).filter(key => key.length);
+      const uniqueKeys = [...new Set(keys)];
+      
+      this.errorMessage = keys.length !== uniqueKeys.length
+        ? "Keys must be unique"
+        : null;
+
+     this.$emit("error", !!this.errorMessage);
+    },
   },
   watch: {
     metadata() {

--- a/client/src/components/Metadata.vue
+++ b/client/src/components/Metadata.vue
@@ -181,7 +181,6 @@ export default {
 }
 
 .meta-item {
-  padding: 3px;
   background-color: inherit;
   padding-top: 2px !important;
   padding-bottom: 2px !important;

--- a/client/src/components/TagsInput.vue
+++ b/client/src/components/TagsInput.vue
@@ -143,18 +143,16 @@ export default {
       type: Function,
       default: () => true
     },
-
     addTagsOnComma: {
       type: Boolean,
       default: false
     },
-
     wrapperClass: {
       type: String,
       default: "tags-input-wrapper-default"
     }
   },
-
+  
   data() {
     return {
       badgeId: 0,
@@ -268,7 +266,7 @@ export default {
 
       // Emit events
       this.$emit("tag-added", slug);
-      this.$emit("tags-updated");
+      this.$emit("tags-updated", this.tags);
     },
 
     removeLastTag() {
@@ -285,7 +283,7 @@ export default {
 
       // Emit events
       this.$emit("tag-removed", slug);
-      this.$emit("tags-updated");
+      this.$emit("tags-updated", this.tags);
     },
 
     searchTag() {
@@ -448,5 +446,6 @@ export default {
 <style>
 .tags-input-root {
   position: relative;
+  width: 100%;
 }
 </style>

--- a/client/src/components/cards/DatasetCard.vue
+++ b/client/src/components/cards/DatasetCard.vue
@@ -127,13 +127,21 @@
                   :typeahead-activation-threshold="0"
                 />
               </div>
+              <hr />
 
               <Metadata
                 :metadata="defaultMetadata"
-                title="Default Annotation Metadata (Tags)"
-                key-name="Default Key"
-                value-name="Default Value"
+                title="Default Annotation Metadata"
                 ref="defaultAnnotation"
+                v-on:error="onValidationError($event)"
+              />
+              <hr />
+
+                            <Metadata
+                :metadata="datasetTags"
+                title="Dataset Tags"
+                ref="datasetTags"
+                empty-message="No tags"
                 v-on:error="onValidationError($event)"
               />
             </form>
@@ -239,6 +247,7 @@ export default {
       imageError: false,
       selectedCategories: [],
       defaultMetadata: this.dataset.default_annotation_metadata,
+      datasetTags: this.dataset.tags,
       noImageUrl: require("@/assets/no-image.png"),
       notFoundImageUrl: require("@/assets/404-image.png"),
       sharedUsers: [],
@@ -287,11 +296,13 @@ export default {
     onSave() {
       this.dataset.categories = this.selectedCategories;
       this.$refs.defaultAnnotation.clearEmptyItems();
+      this.$refs.datasetTags.clearEmptyItems();
 
       axios
         .post("/api/dataset/" + this.dataset.id, {
           categories: this.selectedCategories,
-          default_annotation_metadata: this.$refs.defaultAnnotation.export()
+          default_annotation_metadata: this.$refs.defaultAnnotation.export(),
+          tags: this.$refs.datasetTags.export()
         })
         .then(() => {
           this.$parent.updatePage();

--- a/client/src/components/cards/DatasetCard.vue
+++ b/client/src/components/cards/DatasetCard.vue
@@ -130,10 +130,11 @@
 
               <Metadata
                 :metadata="defaultMetadata"
-                title="Default Annotation Metadata"
+                title="Default Annotation Metadata (Tags)"
                 key-name="Default Key"
                 value-name="Default Value"
                 ref="defaultAnnotation"
+                v-on:error="onValidationError($event)"
               />
             </form>
           </div>
@@ -143,6 +144,7 @@
               class="btn btn-success"
               @click="onSave"
               data-dismiss="modal"
+              :disabled="!allowSave"
             >
               Save
             </button>
@@ -239,7 +241,8 @@ export default {
       defaultMetadata: this.dataset.default_annotation_metadata,
       noImageUrl: require("@/assets/no-image.png"),
       notFoundImageUrl: require("@/assets/404-image.png"),
-      sharedUsers: []
+      sharedUsers: [],
+      allowSave: true,
     };
   },
   methods: {
@@ -278,8 +281,12 @@ export default {
         this.$parent.updatePage();
       });
     },
+    onValidationError(error) {
+      this.allowSave = !error;
+    },
     onSave() {
       this.dataset.categories = this.selectedCategories;
+      this.$refs.defaultAnnotation.clearEmptyItems();
 
       axios
         .post("/api/dataset/" + this.dataset.id, {
@@ -389,6 +396,7 @@ p {
   padding: 2px;
   background-color: #4b5162;
 }
+
 .icon-more {
   width: 10%;
   margin: 3px 0;
@@ -401,6 +409,7 @@ p {
   margin: 0 5px 7px 5px;
   height: 5px;
 }
+
 .card-footer {
   padding: 2px;
   font-size: 11px;

--- a/client/src/components/cards/DatasetCard.vue
+++ b/client/src/components/cards/DatasetCard.vue
@@ -137,7 +137,7 @@
               />
               <hr />
 
-                            <Metadata
+              <Metadata
                 :metadata="datasetTags"
                 title="Dataset Tags"
                 ref="datasetTags"

--- a/client/src/models/datasets.js
+++ b/client/src/models/datasets.js
@@ -6,9 +6,16 @@ export default {
   allData(params) {
     return axios.get(`${baseURL}/data`, {
       params: {
-        ...params
+        ...params,
       }
     });
+  },
+  getFilterOptions(params) {
+    return axios.get(`${baseURL}/filters`, {
+      params: {
+        ...params
+      }
+    })
   },
   getData(id, params) {
     return axios.get(`${baseURL}/${id}/data`, {


### PR DESCRIPTION
# Purpose

Currently, datasets are arranged in the dataset viewer in a flat structure, making it difficult to manage a large number of datasets. This PR introduces two features to address this problem:

#### 1. Ability to tag a dataset with arbitrary keys and values. 
An interface is added to the client side for inputting keys and values for each dataset. Keys must be unique per dataset.
<img width="1420" alt="Screen Shot 2022-07-08 at 4 38 10 PM" src="https://user-images.githubusercontent.com/61648005/177955029-e2696695-e952-4114-9d98-df25b9b724d7.png">

On the server side, the tags are held in each dataset document in a `tags` dictionary property.

#### 2. Ability to filter datasets in the dataset viewer according to tags.
An input form is added to the client to be able to type or select tags that can be used to filter the datasets on the server side. The tag options come from a new API route that serves all unique tags across all datasets per user.
<img width="1418" alt="Screen Shot 2022-07-08 at 4 38 49 PM" src="https://user-images.githubusercontent.com/61648005/177955645-9d094125-4334-44d5-860b-22a868dda449.png">

# Wishes

@tintn @niccololampa This PR does not yet include a new 'Tags' page in the UI. The basic functionality is there but I'm thinking a separate Tags page would be needed to enable assigning tags to existing datasets in bulk. I can continue to work on it here or create a new PR to prevent this one from becoming too big --  please let me know what you think.